### PR TITLE
Add divider to welcome message

### DIFF
--- a/src/picky/picky.js
+++ b/src/picky/picky.js
@@ -80,6 +80,9 @@ export default class Picky {
             text: '*Welcome!* \n(nit)Picky explains acronyms used in your channels. Invite Picky; it will respond with an explanation every time someone uses an acronym. Picky will remember all the acronyms that it has listened to and explain. However, Picky will make up random acronym meanings unless someone explains them.',
           },
         },
+        {
+          type: 'divider',
+        },
       ],
     };
 


### PR DESCRIPTION
### TL;DR
Added a divider line to the welcome message in Picky bot.

### What changed?
Added a visual divider element between the welcome message and subsequent content in the Picky bot's interface.

### How to test?
1. Invite Picky bot to a channel
2. Verify that the welcome message now includes a divider line below the text

### Why make this change?
Improves visual separation and readability of the welcome message from other content in the bot's interface.