### PR TITLE
Add acronym list section with checkboxes

### DIFF
--- a/src/picky/picky.js
+++ b/src/picky/picky.js
@@ -83,6 +83,34 @@ export default class Picky {
         {
           type: 'divider',
         },
+        {
+          type: 'section',
+          text: {
+            type: 'plain_text',
+            text: 'List of existing acronyms',
+          },
+          accessory: {
+            type: 'checkboxes',
+            action_id: 'delete_definitions',
+            initial_options: [],
+            options: [
+              {
+                value: 'ABC Another Beautiful Croquette',
+                text: {
+                  type: 'plain_text',
+                  text: 'ABC: Another Beautiful Croquette',
+                },
+              },
+              {
+                value: 'DEF Definitely Enough Focaccia',
+                text: {
+                  type: 'plain_text',
+                  text: 'DEF: Definitely Enough Focaccia',
+                },
+              },
+            ],
+          },
+        },
       ],
     };
 


### PR DESCRIPTION
### TL;DR
Added a new section to display existing acronyms with checkboxes in the Picky interface.

### What changed?
Added a new section component that shows a list of existing acronyms (ABC and DEF) with corresponding definitions. Each acronym is displayed with a checkbox, allowing users to select multiple entries through the `delete_definitions` action.

### How to test?
1. Open the Picky interface
2. Verify that the "List of existing acronyms" section appears
3. Confirm that the following acronyms are displayed with checkboxes:
   - ABC: Another Beautiful Croquette
   - DEF: Definitely Enough Focaccia
4. Verify that the checkboxes are interactive and can be selected

### Why make this change?
To provide users with a visual representation of existing acronyms in the system and enable them to select multiple entries for potential deletion or management purposes.