### PR TITLE
Add delete button with confirmation dialog

### DIFF
--- a/src/picky/picky.js
+++ b/src/picky/picky.js
@@ -111,6 +111,34 @@ export default class Picky {
             ],
           },
         },
+        {
+          type: 'actions',
+          elements: [
+            {
+              type: 'button',
+              text: {
+                type: 'plain_text',
+                text: 'Delete selected definitions',
+              },
+              style: 'danger',
+              action_id: 'delete_selected_definitions',
+              confirm: {
+                title: {
+                  type: 'plain_text',
+                  text: 'Are you sure?',
+                },
+                confirm: {
+                  type: 'plain_text',
+                  text: 'Do it',
+                },
+                deny: {
+                  type: 'plain_text',
+                  text: "Stop, I've changed my mind!",
+                },
+              },
+            },
+          ],
+        },
       ],
     };
 


### PR DESCRIPTION
### TL;DR
Added a delete button with confirmation dialog for removing selected definitions

### What changed?
Added a new danger-styled button that allows users to delete selected definitions. The button includes a confirmation dialog that asks users to confirm their action before proceeding with deletion.

### How to test?
1. Navigate to the definitions view
2. Select one or more definitions
3. Click the "Delete selected definitions" button
4. Verify that the confirmation dialog appears
5. Test both confirmation and cancellation flows

### Why make this change?
To provide users with a way to bulk delete definitions they no longer need, while ensuring they don't accidentally delete important definitions through the confirmation dialog.